### PR TITLE
[Merged by Bors] - feat(json-sql): update json-sql to support upsert

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ Every step would be same except the connector config and the behavior of the con
 
 We have a `operation` parameter which defaults to `insert` but we can pass `upsert` here to specify we want to do an upsert operation.
 
-Upsert additionaly takes an `unique_columns` argument. `unique_columns` specifies the list indices or column names to check for uniqueness of a record.
-If a record with same value in `unique_columns` exists in the database, it will be updated. If no record exists with same value, the given record will
+Upsert additionaly takes an `unique-columns` argument. `unique-columns` specifies the list indices or column names to check for uniqueness of a record.
+If a record with same value in `unique-columns` exists in the database, it will be updated. If no record exists with same value, the given record will
 be inserted.
 
 Connector configuration file for upsert (assuming `device_id` is a unique column or an index in the database):

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ meta:
 sql:
   url: ${{ secrets.DATABASE_URL }}
 ```
-## Usage Example
+## Insert Usage Example
 Let's look at the example of the connector with one transformation named [infinyon/json-sql](https://github.com/infinyon/fluvio-connectors/blob/main/smartmodules/json-sql/README.md). The transformation takes
 records in JSON format and creates SQL insert operation to `topic_message` table. The value from `device.device_id`
 JSON field will be put to `device_id` column and the entire json body to `record` column.
@@ -139,3 +139,49 @@ cdk deploy shutdown --config connector-config.yaml
 After you run the connector you will see records in your database table.
 
 See more in our [Build MQTT to SQL Pipeline](https://www.fluvio.io/docs/tutorials/mqtt-to-sql/) and [Build HTTP to SQL Pipeline](https://www.fluvio.io/docs/tutorials/data-pipeline/) tutorials.
+
+## Upsert Usage Example
+
+Every step would be same except the connector config and the behavior of the connector after deployment.
+
+We have a `operation` parameter which defaults to `insert` but we can pass `upsert` here to specify we want to do an upsert operation.
+
+Upsert additionaly takes an `uniq_idx` argument. `uniq_idx` specifies the index or column name to check for uniqueness of a record.
+If a record with same value in `uniq_idx` exists in the database, it will be updated. If no record exists with same value, the given record will
+be inserted.
+
+Connector configuration file for upsert (assuming `device_id` is a unique column or an index in the database):
+
+```yaml
+# connector-config.yaml
+apiVersion: 0.1.0
+meta:
+  version: 0.3.1
+  name: json-sql-connector
+  type: sql-sink
+  topic: sql-topic
+  create-topic: true
+  secrets:
+    - name: DATABASE_URL
+sql:
+  url: ${{ secrets.DATABASE_URL }}
+transforms:
+  - uses: infinyon/json-sql
+    with:
+      mapping:
+        operation: "upsert"
+        uniq-idx: "device_id"
+        table: "topic_message"
+        map-columns:
+          "device_id":
+            json-key: "device.device_id"
+            value:
+              type: "int"
+              default: "0"
+              required: true
+          "record":
+            json-key: "$"
+            value:
+              type: "jsonb"
+              required: true
+```

--- a/README.md
+++ b/README.md
@@ -185,3 +185,6 @@ transforms:
               type: "jsonb"
               required: true
 ```
+
+See more about upsert in [our blog](https://infinyon.com/blog/2023/07/sql-upsert/).
+Note: the blog doesn't use `json-sql` smartmodule and has hardcoded records for demonstration. `sql-connector` is intended to be used with `json-sql`.

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ Every step would be same except the connector config and the behavior of the con
 
 We have a `operation` parameter which defaults to `insert` but we can pass `upsert` here to specify we want to do an upsert operation.
 
-Upsert additionaly takes an `uniq_idx` argument. `uniq_idx` specifies the index or column name to check for uniqueness of a record.
-If a record with same value in `uniq_idx` exists in the database, it will be updated. If no record exists with same value, the given record will
+Upsert additionaly takes an `unique_columns` argument. `unique_columns` specifies the list indices or column names to check for uniqueness of a record.
+If a record with same value in `unique_columns` exists in the database, it will be updated. If no record exists with same value, the given record will
 be inserted.
 
 Connector configuration file for upsert (assuming `device_id` is a unique column or an index in the database):
@@ -170,7 +170,8 @@ transforms:
     with:
       mapping:
         operation: "upsert"
-        uniq-idx: "device_id"
+        unique-columns:
+          - "device_id"
         table: "topic_message"
         map-columns:
           "device_id":

--- a/crates/json-sql/README.md
+++ b/crates/json-sql/README.md
@@ -135,15 +135,15 @@ Currently `insert` and `upsert` are supported.
 
 #### Upsert
 
-Upsert additionaly takes an `uniq_idx` argument. `uniq_idx` specifies the index or column name to check for uniqueness of a record.
-If a record with same value in `uniq_idx` exists in the database, it will be updated. If no record exists with same value, the given record will
+Upsert additionaly takes an `unique_columns` argument. `unique_columns` specifies the list indices or column names to check for uniqueness of a record.
+If a record with same value in `unique_columns` exists in the database, it will be updated. If no record exists with same value, the given record will
 be inserted.
 
 ```json
 {
   "table" : "target_table",
   "operation": "upsert",
-  "uniq_idx": "my_unique_column",
+  "unique-columns": ["my_unique_column"],
   "map-columns": {
     "target_column_name" : {
       "json-key": "device.number",

--- a/crates/json-sql/README.md
+++ b/crates/json-sql/README.md
@@ -135,8 +135,8 @@ Currently `insert` and `upsert` are supported.
 
 #### Upsert
 
-Upsert additionaly takes an `unique_columns` argument. `unique_columns` specifies the list indices or column names to check for uniqueness of a record.
-If a record with same value in `unique_columns` exists in the database, it will be updated. If no record exists with same value, the given record will
+Upsert additionaly takes an `unique-columns` argument. `unique-columns` specifies the list indices or column names to check for uniqueness of a record.
+If a record with same value in `unique-columns` exists in the database, it will be updated. If no record exists with same value, the given record will
 be inserted.
 
 ```json

--- a/crates/json-sql/README.md
+++ b/crates/json-sql/README.md
@@ -9,6 +9,7 @@ and the output corresponding SQL operation. For example:
 ```json
 {
   "table" : "target_table",
+  "operation": "insert",
   "map-columns": {
     "target_column_name" : {
       "json-key": "device.number",
@@ -111,3 +112,45 @@ The list of supported types and corresponding types from [SQL model](../fluvio-m
 | json, jsonb                                 | Json            |
 | uuid                                        | Uuid            |
 
+### Operations
+
+Currently `insert` and `upsert` are supported.
+
+#### Insert
+
+```json
+{
+  "table" : "target_table",
+  "operation": "insert",
+  "map-columns": {
+    "target_column_name" : {
+      "json-key": "device.number",
+      "value": {
+        "type": "int4"
+      }
+    }
+  }
+}
+```
+
+#### Upsert
+
+Upsert additionaly takes an `uniq_idx` argument. `uniq_idx` specifies the index or column name to check for uniqueness of a record.
+If a record with same value in `uniq_idx` exists in the database, it will be updated. If no record exists with same value, the given record will
+be inserted.
+
+```json
+{
+  "table" : "target_table",
+  "operation": "upsert",
+  "uniq_idx": "my_unique_column",
+  "map-columns": {
+    "target_column_name" : {
+      "json-key": "device.number",
+      "value": {
+        "type": "int4"
+      }
+    }
+  }
+}
+```

--- a/crates/json-sql/SmartModule.toml
+++ b/crates/json-sql/SmartModule.toml
@@ -1,7 +1,7 @@
 [package]
 name = "json-sql"
 group = "infinyon"
-version = "0.1.1"
+version = "0.2.0"
 apiVersion = "0.1.0"
 description = "JSON to SQL transformation Smartmodule"
 license = "Apache-2.0"

--- a/crates/json-sql/SmartModule.toml
+++ b/crates/json-sql/SmartModule.toml
@@ -1,7 +1,7 @@
 [package]
 name = "json-sql"
 group = "infinyon"
-version = "0.1.0"
+version = "0.1.1"
 apiVersion = "0.1.0"
 description = "JSON to SQL transformation Smartmodule"
 license = "Apache-2.0"

--- a/crates/json-sql/src/mapping.rs
+++ b/crates/json-sql/src/mapping.rs
@@ -12,7 +12,8 @@ pub struct Mapping {
     #[serde(default = "default_op")]
     pub operation: Operation,
     // only used when operation is upsert
-    pub uniq_idx: Option<String>,
+    #[serde(default)]
+    pub unique_columns: Vec<String>,
     #[serde(alias = "map-columns")]
     pub columns: HashMap<String, Column>,
 }
@@ -232,7 +233,7 @@ mod tests {
             mapping,
             Mapping {
                 operation: Operation::Insert,
-                uniq_idx: None,
+                unique_columns: Default::default(),
                 table: "test_table".to_string(),
                 columns: HashMap::from([(
                     "column_name".to_string(),
@@ -255,7 +256,10 @@ mod tests {
         let input = json!({
             "table" : "test_table",
             "operation": "upsert",
-            "uniq-idx": "my_idx",
+            "unique-columns": [
+                "my_idx",
+                "my_idx2"
+            ],
             "map-columns": {
                 "column_name" : {
                     "json-key": "test-key",
@@ -276,7 +280,7 @@ mod tests {
             mapping,
             Mapping {
                 operation: Operation::Upsert,
-                uniq_idx: Some("my_idx".into()),
+                unique_columns: vec!["my_idx".to_owned(), "my_idx2".to_owned()],
                 table: "test_table".to_string(),
                 columns: HashMap::from([(
                     "column_name".to_string(),
@@ -317,7 +321,7 @@ mod tests {
             mapping,
             Mapping {
                 operation: Operation::Insert,
-                uniq_idx: None,
+                unique_columns: Default::default(),
                 table: "test_table".to_string(),
                 columns: HashMap::from([(
                     "column_name".to_string(),
@@ -358,7 +362,7 @@ mod tests {
             mapping,
             Mapping {
                 operation: Operation::Insert,
-                uniq_idx: None,
+                unique_columns: Default::default(),
                 table: "test_table".to_string(),
                 columns: HashMap::from([(
                     "column_name".to_string(),
@@ -399,7 +403,7 @@ mod tests {
             mapping,
             Mapping {
                 operation: Operation::Insert,
-                uniq_idx: None,
+                unique_columns: Default::default(),
                 table: "test_table".to_string(),
                 columns: HashMap::from([(
                     "column_name".to_string(),
@@ -438,7 +442,7 @@ mod tests {
             mapping,
             Mapping {
                 operation: Operation::Insert,
-                uniq_idx: None,
+                unique_columns: Default::default(),
                 table: "test_table".to_string(),
                 columns: HashMap::from([(
                     "column_name".to_string(),

--- a/crates/json-sql/src/mapping.rs
+++ b/crates/json-sql/src/mapping.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use std::fmt;
 
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
 pub struct Mapping {
     pub table: String,
     #[serde(default = "default_op")]

--- a/crates/json-sql/src/transform.rs
+++ b/crates/json-sql/src/transform.rs
@@ -32,14 +32,17 @@ pub(crate) fn transform(record: serde_json::Value, mapping: &Mapping) -> Result<
             table: mapping.table.clone(),
             values,
         }),
-        MappingOperation::Upsert => Operation::Upsert(Upsert {
-            table: mapping.table.clone(),
-            values,
-            uniq_idx: mapping
-                .uniq_idx
-                .clone()
-                .ok_or_else(|| eyre!("Missing uniq_idx when mapping upsert."))?,
-        }),
+        MappingOperation::Upsert => {
+            if mapping.unique_columns.is_empty() {
+                return Err(eyre!("unique-columns can't be empty when doing upsert"));
+            }
+
+            Operation::Upsert(Upsert {
+                table: mapping.table.clone(),
+                values,
+                uniq_idx: mapping.unique_columns.join(", "),
+            })
+        }
     };
 
     Ok(op)


### PR DESCRIPTION
Done as discussed.

Implementation of `uniq_idx` got a bit dirty because I couldn't figure a way to establish the api we decided in another way.

Updated README files to mention upsert