### PR TITLE
feat: use integrated logging from `fluvio`@`0.10.13`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,8 +1108,8 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.19.2"
-source = "git+https://github.com/infinyon/fluvio.git?tag=v0.10.12#69979cd9a9f771a6917319d1e24fee44698bdfbc"
+version = "0.19.3"
+source = "git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d#92771981594df8b75a8eca0a321ec93cc47d492d"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1125,13 +1125,13 @@ dependencies = [
  "event-listener",
  "fluvio-compression 0.3.0",
  "fluvio-future",
- "fluvio-protocol 0.10.2",
+ "fluvio-protocol 0.10.4",
  "fluvio-sc-schema",
  "fluvio-smartengine",
- "fluvio-smartmodule 0.7.0",
+ "fluvio-smartmodule 0.7.1",
  "fluvio-socket",
  "fluvio-spu-schema",
- "fluvio-types 0.4.2 (git+https://github.com/infinyon/fluvio.git?tag=v0.10.12)",
+ "fluvio-types 0.4.2 (git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d)",
  "futures-util",
  "once_cell",
  "pin-project",
@@ -1162,7 +1162,7 @@ dependencies = [
 [[package]]
 name = "fluvio-compression"
 version = "0.3.0"
-source = "git+https://github.com/infinyon/fluvio.git?tag=v0.10.12#69979cd9a9f771a6917319d1e24fee44698bdfbc"
+source = "git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d#92771981594df8b75a8eca0a321ec93cc47d492d"
 dependencies = [
  "bytes",
  "flate2",
@@ -1176,7 +1176,7 @@ dependencies = [
 [[package]]
 name = "fluvio-connector-common"
 version = "0.0.0"
-source = "git+https://github.com/infinyon/fluvio.git?tag=v0.10.12#69979cd9a9f771a6917319d1e24fee44698bdfbc"
+source = "git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d#92771981594df8b75a8eca0a321ec93cc47d492d"
 dependencies = [
  "anyhow",
  "async-net",
@@ -1198,7 +1198,7 @@ dependencies = [
 [[package]]
 name = "fluvio-connector-derive"
 version = "0.0.0"
-source = "git+https://github.com/infinyon/fluvio.git?tag=v0.10.12#69979cd9a9f771a6917319d1e24fee44698bdfbc"
+source = "git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d#92771981594df8b75a8eca0a321ec93cc47d492d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1208,7 +1208,7 @@ dependencies = [
 [[package]]
 name = "fluvio-connector-package"
 version = "0.0.0"
-source = "git+https://github.com/infinyon/fluvio.git?tag=v0.10.12#69979cd9a9f771a6917319d1e24fee44698bdfbc"
+source = "git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d#92771981594df8b75a8eca0a321ec93cc47d492d"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -1216,10 +1216,9 @@ dependencies = [
  "fluvio-compression 0.3.0",
  "fluvio-controlplane-metadata",
  "fluvio-smartengine",
- "fluvio-types 0.4.2 (git+https://github.com/infinyon/fluvio.git?tag=v0.10.12)",
+ "fluvio-types 0.4.2 (git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d)",
  "humantime-serde",
  "minijinja",
- "once_cell",
  "openapiv3",
  "serde",
  "serde_yaml",
@@ -1229,8 +1228,8 @@ dependencies = [
 
 [[package]]
 name = "fluvio-controlplane-metadata"
-version = "0.22.3"
-source = "git+https://github.com/infinyon/fluvio.git?tag=v0.10.12#69979cd9a9f771a6917319d1e24fee44698bdfbc"
+version = "0.22.4"
+source = "git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d#92771981594df8b75a8eca0a321ec93cc47d492d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1240,9 +1239,9 @@ dependencies = [
  "derive_builder",
  "flate2",
  "fluvio-future",
- "fluvio-protocol 0.10.2",
+ "fluvio-protocol 0.10.4",
  "fluvio-stream-model",
- "fluvio-types 0.4.2 (git+https://github.com/infinyon/fluvio.git?tag=v0.10.12)",
+ "fluvio-types 0.4.2 (git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d)",
  "flv-util",
  "humantime-serde",
  "lenient_semver",
@@ -1307,8 +1306,8 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.10.2"
-source = "git+https://github.com/infinyon/fluvio.git?tag=v0.10.12#69979cd9a9f771a6917319d1e24fee44698bdfbc"
+version = "0.10.4"
+source = "git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d#92771981594df8b75a8eca0a321ec93cc47d492d"
 dependencies = [
  "bytes",
  "content_inspector",
@@ -1316,8 +1315,8 @@ dependencies = [
  "eyre",
  "fluvio-compression 0.3.0",
  "fluvio-future",
- "fluvio-protocol-derive 0.5.2",
- "fluvio-types 0.4.2 (git+https://github.com/infinyon/fluvio.git?tag=v0.10.12)",
+ "fluvio-protocol-derive 0.5.3",
+ "fluvio-types 0.4.2 (git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d)",
  "flv-util",
  "once_cell",
  "semver",
@@ -1340,8 +1339,8 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-derive"
-version = "0.5.2"
-source = "git+https://github.com/infinyon/fluvio.git?tag=v0.10.12#69979cd9a9f771a6917319d1e24fee44698bdfbc"
+version = "0.5.3"
+source = "git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d#92771981594df8b75a8eca0a321ec93cc47d492d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1351,14 +1350,14 @@ dependencies = [
 
 [[package]]
 name = "fluvio-sc-schema"
-version = "0.19.1"
-source = "git+https://github.com/infinyon/fluvio.git?tag=v0.10.12#69979cd9a9f771a6917319d1e24fee44698bdfbc"
+version = "0.19.2"
+source = "git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d#92771981594df8b75a8eca0a321ec93cc47d492d"
 dependencies = [
  "anyhow",
  "fluvio-controlplane-metadata",
- "fluvio-protocol 0.10.2",
+ "fluvio-protocol 0.10.4",
  "fluvio-socket",
- "fluvio-types 0.4.2 (git+https://github.com/infinyon/fluvio.git?tag=v0.10.12)",
+ "fluvio-types 0.4.2 (git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d)",
  "paste",
  "static_assertions",
  "thiserror",
@@ -1367,15 +1366,16 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartengine"
-version = "0.7.5"
-source = "git+https://github.com/infinyon/fluvio.git?tag=v0.10.12#69979cd9a9f771a6917319d1e24fee44698bdfbc"
+version = "0.7.6"
+source = "git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d#92771981594df8b75a8eca0a321ec93cc47d492d"
 dependencies = [
  "anyhow",
  "cfg-if",
  "derive_builder",
  "fluvio-future",
- "fluvio-protocol 0.10.2",
- "fluvio-smartmodule 0.7.0",
+ "fluvio-protocol 0.10.4",
+ "fluvio-smartmodule 0.7.1",
+ "humantime-serde",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1399,12 +1399,12 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartmodule"
-version = "0.7.0"
-source = "git+https://github.com/infinyon/fluvio.git?tag=v0.10.12#69979cd9a9f771a6917319d1e24fee44698bdfbc"
+version = "0.7.1"
+source = "git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d#92771981594df8b75a8eca0a321ec93cc47d492d"
 dependencies = [
  "eyre",
- "fluvio-protocol 0.10.2",
- "fluvio-smartmodule-derive 0.5.0",
+ "fluvio-protocol 0.10.4",
+ "fluvio-smartmodule-derive 0.6.0",
  "thiserror",
  "tracing",
 ]
@@ -1422,18 +1422,18 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartmodule-derive"
-version = "0.5.0"
-source = "git+https://github.com/infinyon/fluvio.git?tag=v0.10.12#69979cd9a9f771a6917319d1e24fee44698bdfbc"
+version = "0.6.0"
+source = "git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d#92771981594df8b75a8eca0a321ec93cc47d492d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.22",
 ]
 
 [[package]]
 name = "fluvio-socket"
 version = "0.14.4"
-source = "git+https://github.com/infinyon/fluvio.git?tag=v0.10.12#69979cd9a9f771a6917319d1e24fee44698bdfbc"
+source = "git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d#92771981594df8b75a8eca0a321ec93cc47d492d"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -1443,7 +1443,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "fluvio-future",
- "fluvio-protocol 0.10.2",
+ "fluvio-protocol 0.10.4",
  "futures-util",
  "once_cell",
  "pin-project",
@@ -1456,17 +1456,17 @@ dependencies = [
 
 [[package]]
 name = "fluvio-spu-schema"
-version = "0.14.2"
-source = "git+https://github.com/infinyon/fluvio.git?tag=v0.10.12#69979cd9a9f771a6917319d1e24fee44698bdfbc"
+version = "0.14.3"
+source = "git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d#92771981594df8b75a8eca0a321ec93cc47d492d"
 dependencies = [
  "bytes",
  "derive_builder",
  "educe",
  "flate2",
  "fluvio-future",
- "fluvio-protocol 0.10.2",
- "fluvio-smartmodule 0.7.0",
- "fluvio-types 0.4.2 (git+https://github.com/infinyon/fluvio.git?tag=v0.10.12)",
+ "fluvio-protocol 0.10.4",
+ "fluvio-smartmodule 0.7.1",
+ "fluvio-types 0.4.2 (git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d)",
  "serde",
  "static_assertions",
  "tracing",
@@ -1475,7 +1475,7 @@ dependencies = [
 [[package]]
 name = "fluvio-stream-model"
 version = "0.9.2"
-source = "git+https://github.com/infinyon/fluvio.git?tag=v0.10.12#69979cd9a9f771a6917319d1e24fee44698bdfbc"
+source = "git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d#92771981594df8b75a8eca0a321ec93cc47d492d"
 dependencies = [
  "async-rwlock",
  "event-listener",
@@ -1496,7 +1496,7 @@ dependencies = [
 [[package]]
 name = "fluvio-types"
 version = "0.4.2"
-source = "git+https://github.com/infinyon/fluvio.git?tag=v0.10.12#69979cd9a9f771a6917319d1e24fee44698bdfbc"
+source = "git+https://github.com/EstebanBorai/fluvio.git?rev=92771981594df8b75a8eca0a321ec93cc47d492d#92771981594df8b75a8eca0a321ec93cc47d492d"
 dependencies = [
  "event-listener",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ inherits = "release"
 lto = true
 
 [workspace.dependencies]
-fluvio = { git = "https://github.com/infinyon/fluvio.git", tag = "v0.10.12" }
-fluvio-connector-common = { git = "https://github.com/infinyon/fluvio.git", tag = "v0.10.12" }
+fluvio = { git = "https://github.com/EstebanBorai/fluvio.git", rev = "f4b811030400218685c7dcb60bf3f02a4640b979" }
+fluvio-connector-common = { git = "https://github.com/EstebanBorai/fluvio.git", rev = "f4b811030400218685c7dcb60bf3f02a4640b979" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ inherits = "release"
 lto = true
 
 [workspace.dependencies]
-fluvio = { git = "https://github.com/EstebanBorai/fluvio.git", rev = "f4b811030400218685c7dcb60bf3f02a4640b979" }
-fluvio-connector-common = { git = "https://github.com/EstebanBorai/fluvio.git", rev = "f4b811030400218685c7dcb60bf3f02a4640b979" }
+fluvio = { git = "https://github.com/EstebanBorai/fluvio.git", rev = "92771981594df8b75a8eca0a321ec93cc47d492d" }
+fluvio-connector-common = { git = "https://github.com/EstebanBorai/fluvio.git", rev = "92771981594df8b75a8eca0a321ec93cc47d492d" }


### PR DESCRIPTION
Updates `fluvio` deps to `0.10.13` in order to use https://github.com/infinyon/fluvio/commit/766b77fc25526a610b5d8ce9c0234c44fa2cca33