### PR TITLE
[Merged by Bors] - feat(workflow): add workflow for publishing `json-sql` to hub

### DIFF
--- a/.github/workflows/publish-json-sql.yaml
+++ b/.github/workflows/publish-json-sql.yaml
@@ -1,0 +1,61 @@
+name: Publish Hub
+
+permissions: read-all
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "The branch, tag or SHA to checkout"
+        required: true
+        type: string
+        default: "main"
+      smartmodule-version:
+        description: "The version of the smartmodule, should be same as in the SmartModule.toml"
+        required: true
+        type: string
+      target_prod:
+        description: "Target the prod hub"
+        required: true
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+    steps:
+      - name: Install Fluvio
+        run: |
+          curl -fsS https://hub.infinyon.cloud/install/install.sh | bash
+          echo "$HOME/.fluvio/bin" >> $GITHUB_PATH
+      - name: Install Fluvio SMDK
+        run: fluvio install smdk
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
+      - name: Setup wasm32-unknown-unknown target 
+        run: rustup target add wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: "false"
+          cache-on-failure: "true"
+      - name: Build
+        run: smdk build -p json-sql
+      - name: Pack
+        run: smdk publish -p json-sql --pack
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: smartmodule-artifact
+          path: smartmodule/.hub/json-sql-${{ github.event.inputs.smartmodule-version }}.ipkg
+  publish:
+    needs: build
+    uses: infinyon/fluvio/.github/workflows/smartmodule-publish.yml@master
+    with:
+      fail-fast: false
+      target_prod: ${{ github.event.inputs.target_prod }}
+      artifact-name: smartmodule-artifact
+      ipkg-file-name: json-sql-${{ github.event.inputs.smartmodule-version }}.ipkg
+    secrets: inherit

--- a/.github/workflows/publish-json-sql.yaml
+++ b/.github/workflows/publish-json-sql.yaml
@@ -55,7 +55,7 @@ jobs:
     uses: infinyon/fluvio/.github/workflows/smartmodule-publish.yml@master
     with:
       fail-fast: false
-      target_prod: ${{ github.event.inputs.target_prod }}
+      target_prod: ${{ inputs.target_prod }}
       artifact-name: smartmodule-artifact
       ipkg-file-name: json-sql-${{ github.event.inputs.smartmodule-version }}.ipkg
     secrets: inherit


### PR DESCRIPTION
This adds a new workflow for publishing `json-sql` smartmodule to the hub.

It uses the reusable publish workflow for smartmodules defined at [here](https://github.com/infinyon/fluvio/blob/master/.github/workflows/smartmodule-publish.yml).

A similar workflow can be found [here](https://github.com/infinyon/fluvio-jolt/blob/main/.github/workflows/publish.yaml).