### PR TITLE
[Merged by Bors] - ci: don't login to cloud, use local json-sql

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Install Fluvio SMDK
         run: fluvio install smdk
       - name: Run Integration Test
-        timeout-minutes: 20
+        timeout-minutes: 30
         run: make integration_tests
 
   done:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,12 +108,10 @@ jobs:
           sleep 3
           echo foo | fluvio produce foobar
           fluvio consume foobar -B -d
-      - name: Login to Fluvio Cloud
-        run: |
-          fluvio cloud login --email ${{ secrets.DEV_HUB_USER_EMAIL }} --password ${{ secrets.DEV_HUB_USER_PASSWORD }} --remote ${{ vars.DEV_CLOUD_URL }}
-          fluvio profile switch k3d-fluvio
       - name: Install Fluvio CDK
         run: fluvio install cdk
+      - name: Install Fluvio SMDK
+        run: fluvio install smdk
       - name: Run Integration Test
         timeout-minutes: 20
         run: make integration_tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,8 @@ jobs:
           sleep 3
           echo foo | fluvio produce foobar
           fluvio consume foobar -B -d
+      - name: Install wasm target
+        run: rustup target add wasm32-unknown-unknown
       - name: Install Fluvio CDK
         run: fluvio install cdk
       - name: Install Fluvio SMDK

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 integration_tests:
 	cdk build -p sql-sink
+	smdk build -p json-sql
 	smdk load -p json-sql
 	RUST_LOG=warn,integration_tests=info cargo run --release -p integration-tests
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 integration_tests:
 	cdk build -p sql-sink
+	smdk load -p json-sql
 	RUST_LOG=warn,integration_tests=info cargo run --release -p integration-tests
 

--- a/crates/integration-tests/configs/test_postgres_with_json_sql_transformations.yaml
+++ b/crates/integration-tests/configs/test_postgres_with_json_sql_transformations.yaml
@@ -7,7 +7,7 @@ meta:
 sql:
   url: "postgresql://pguser:passpass@127.0.0.1:5432/pguser"
 transforms:
-  - uses: infinyon/json-sql@0.1.0
+  - uses: infinyon/json-sql@0.2.1
     with:
       mapping:
         table: "test_postgres_with_json_sql_transformations"

--- a/crates/integration-tests/src/main.rs
+++ b/crates/integration-tests/src/main.rs
@@ -28,7 +28,6 @@ const POSTGRES_HOST_PORT: &str = "5432";
 const POSTGRES_PASSWORD: &str = "passpass";
 const POSTGRES_USER: &str = "pguser";
 const POSTGRES_DB: &str = POSTGRES_USER;
-const JSON_SQL_PACKAGE_NAME: &str = "infinyon/json-sql@0.1.0";
 
 #[async_std::main]
 async fn main() -> Result<()> {
@@ -236,7 +235,6 @@ async fn test_postgres_with_json_sql_transformations(
     .await
     .context(format!("unable to create table {table})"))?;
 
-    fluvio_download_smartmodule(JSON_SQL_PACKAGE_NAME)?;
     cdk_deploy_start(&config_path, None).await?;
     let connector_name = &config.meta.name;
     let connector_status = cdk_deploy_status(connector_name)?;
@@ -599,22 +597,6 @@ async fn remove_postgres(docker: &Docker) -> Result<()> {
         )
         .await?;
     info!("postgres container removed");
-    Ok(())
-}
-
-fn fluvio_download_smartmodule(smartmodule_name: &str) -> Result<()> {
-    info!("downloading {smartmodule_name} to the cluster");
-    let output = Command::new("fluvio")
-        .arg("hub")
-        .arg("download")
-        .arg(smartmodule_name)
-        .output()?;
-    if !output.status.success() {
-        anyhow::bail!(
-            "`fluvio hub download` failed with:\n {}",
-            String::from_utf8_lossy(output.stderr.as_slice())
-        )
-    }
     Ok(())
 }
 


### PR DESCRIPTION
This PR removes the cloud login from CI and instead loads the local `json-sql` using `smdk`.