### PR TITLE
chore(ci): remove bors files and use merge group for merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  merge_group:
   workflow_dispatch:
   push:
     branches:

--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,0 @@
-status = ["Done"]
-use_squash_merge = true
-delete_merged_branches = true
-timeout_sec = 3600 # 45 mins


### PR DESCRIPTION
Removes `bors.toml` and uses Merge Queue for CI