### PR TITLE
feat: Add a batch insert/upsert mechanism.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4420,9 +4420,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",

--- a/crates/fluvio-model-sql/src/lib.rs
+++ b/crates/fluvio-model-sql/src/lib.rs
@@ -4,8 +4,57 @@ use serde::Serialize;
 /// Top-level list of supported operations in the SQL model.
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub enum Operation {
+    UnInit,
     Insert(Insert),
     Upsert(Upsert),
+    BatchInsert(BatchInsert),
+    BatchUpsert(BatchUpsert),
+}
+
+impl Operation {
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Self::UnInit => 0,
+            Self::Insert(_) => 1,
+            Self::Upsert(_) => 1,
+            Self::BatchInsert(batch_insert) => batch_insert.values.len(),
+            Self::BatchUpsert(batch_upsert) => batch_upsert.values.len(),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        *self = Self::UnInit;
+    }
+
+    pub fn push(&mut self, rhs: Operation) {
+        match rhs {
+            Self::Insert(rhs) => match self {
+                Self::UnInit => *self = Self::Insert(rhs),
+                Self::Insert(lhs) => {
+                    let mut batch_insert: BatchInsert = lhs.clone().into();
+                    batch_insert.values.push(rhs.values);
+                    *self = Self::BatchInsert(batch_insert);
+                }
+                Self::BatchInsert(lhs) => lhs.values.push(rhs.values),
+                _ => unreachable!("insert followed by an upsert Operation can not happen"),
+            },
+            Self::Upsert(rhs) => match self {
+                Self::UnInit => *self = Self::Upsert(rhs),
+                Self::Upsert(lhs) => {
+                    let mut batch_upsert: BatchUpsert = lhs.clone().into();
+                    batch_upsert.values.push(rhs.values);
+                    *self = Self::BatchUpsert(batch_upsert);
+                }
+                Self::BatchUpsert(lhs) => lhs.values.push(rhs.values),
+                _ => unreachable!("upsert followed by an insert Operation can not happen"),
+            },
+            _ => unreachable!("incoming operation other than Insert or Upsert can not happen"),
+        }
+    }
 }
 
 /// SQL Insert operation
@@ -30,6 +79,65 @@ pub struct Value {
     pub raw_value: String,
     #[serde(rename = "type")]
     pub type_: Type,
+}
+
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+pub struct BatchInsert {
+    pub table: String,
+    pub columns: Vec<String>,
+    pub values: Vec<Vec<Value>>,
+}
+
+impl From<Insert> for BatchInsert {
+    fn from(value: Insert) -> Self {
+        let table = value.table;
+        let (columns, values) = value
+            .values
+            .into_iter()
+            .fold((vec![], vec![]), |mut acc, x| {
+                acc.0.push(x.column.clone());
+                acc.1.push(x);
+
+                acc
+            });
+
+        Self {
+            table,
+            columns,
+            values: vec![values],
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+pub struct BatchUpsert {
+    pub table: String,
+    pub columns: Vec<String>,
+    pub values: Vec<Vec<Value>>,
+    pub uniq_idx: String,
+}
+
+impl From<Upsert> for BatchUpsert {
+    fn from(value: Upsert) -> Self {
+        let table = value.table;
+        let uniq_idx = value.uniq_idx;
+        let (columns, values) = value
+            .values
+            .into_iter()
+            .fold((vec![], vec![]), |mut acc, x| {
+                acc.0.push(x.column.clone());
+                acc.1.push(x);
+
+                acc
+            });
+
+        Self {
+            table,
+            columns,
+            values: vec![values],
+            uniq_idx,
+        }
+    }
 }
 
 /// Supported SQL data types.

--- a/crates/sql-sink/src/config.rs
+++ b/crates/sql-sink/src/config.rs
@@ -16,6 +16,14 @@ pub(crate) struct SqlConfig {
     /// Minimum backoff duration to reconnect to the database
     #[serde(with = "humantime_serde", default = "default_backoff_min")]
     pub backoff_min: Duration,
+
+    // The size of batches sent to the database at once
+    #[serde(default)]
+    pub batch_size: Option<usize>,
+
+    // Timeout to send batches, no consequences if batch-size is None
+    #[serde(with = "humantime_serde", default = "default_batch_interval")]
+    pub batch_interval: Duration,
 }
 
 #[inline]
@@ -25,5 +33,10 @@ fn default_backoff_max() -> Duration {
 
 #[inline]
 fn default_backoff_min() -> Duration {
+    Duration::from_secs(1)
+}
+
+#[inline]
+fn default_batch_interval() -> Duration {
     Duration::from_secs(1)
 }

--- a/crates/sql-sink/src/insert.rs
+++ b/crates/sql-sink/src/insert.rs
@@ -7,6 +7,7 @@ use crate::db::Db;
 
 pub trait Insert<DB: Database> {
     fn insert_query(table: &str, values: &[Value]) -> String;
+    fn insert_batch_query(table: &str, columns: &[String], value_sets: &[Vec<Value>]) -> String;
 }
 
 impl Insert<Postgres> for Db {
@@ -15,6 +16,21 @@ impl Insert<Postgres> for Db {
         let values_clause = (1..=values.len()).map(|i| format!("${i}")).join(",");
         format!("INSERT INTO {table} ({columns}) VALUES ({values_clause})")
     }
+
+    fn insert_batch_query(table: &str, columns: &[String], value_sets: &[Vec<Value>]) -> String {
+        let columns = columns.iter().join(",");
+        let mut values = Vec::with_capacity(value_sets.len());
+        for (idx, value_set) in value_sets.iter().enumerate() {
+            values.push(format!(
+                "({})",
+                ((1 + idx * value_set.len())..=(idx * value_set.len() + value_set.len()))
+                    .map(|i| format!("${i}"))
+                    .join(",")
+            ));
+        }
+        let values_clause = values.into_iter().join(",");
+        format!("INSERT INTO {table} ({columns}) VALUES {values_clause}")
+    }
 }
 
 impl Insert<Sqlite> for Db {
@@ -22,5 +38,20 @@ impl Insert<Sqlite> for Db {
         let columns = values.iter().map(|v| v.column.as_str()).join(",");
         let values_clause = (1..=values.len()).map(|_| "?").join(",");
         format!("INSERT INTO {table} ({columns}) VALUES ({values_clause})")
+    }
+
+    fn insert_batch_query(table: &str, columns: &[String], value_sets: &[Vec<Value>]) -> String {
+        let columns = columns.iter().join(",");
+        let mut values = Vec::with_capacity(value_sets.len());
+        for (idx, value_set) in value_sets.iter().enumerate() {
+            values.push(format!(
+                "({})",
+                ((1 + idx * value_set.len())..=(idx * value_set.len() + value_set.len()))
+                    .map(|i| format!("${i}"))
+                    .join(",")
+            ));
+        }
+        let values_clause = values.into_iter().join(",");
+        format!("INSERT INTO {table} ({columns}) VALUES {values_clause}")
     }
 }

--- a/crates/sql-sink/src/upsert.rs
+++ b/crates/sql-sink/src/upsert.rs
@@ -6,6 +6,12 @@ use crate::db::Db;
 
 pub trait Upsert<DB: Database> {
     fn upsert_query(table: &str, values: &[Value], uniq_idx: &str) -> String;
+    fn upsert_batch_query(
+        table: &str,
+        columns: &[String],
+        value_sets: &[Vec<Value>],
+        uniq_idx: &str,
+    ) -> String;
 }
 
 impl Upsert<Postgres> for Db {
@@ -14,13 +20,34 @@ impl Upsert<Postgres> for Db {
         let values_clause = (1..=values.len()).map(|i| format!("${i}")).join(",");
         let set_clause = values
             .iter()
-            .enumerate()
-            .map(|(i, v)| {
-                let idx = i + values.len() + 1;
-                format!("{}=${idx}", v.column)
-            })
+            .map(|v| format!("{}=EXCLUDED.{}", v.column, v.column))
             .join(",");
         format!("INSERT INTO {table} ({columns}) VALUES ({values_clause}) ON CONFLICT({uniq_idx}) DO UPDATE SET {set_clause}")
+    }
+
+    fn upsert_batch_query(
+        table: &str,
+        columns: &[String],
+        value_sets: &[Vec<Value>],
+        uniq_idx: &str,
+    ) -> String {
+        let set_clause = columns
+            .iter()
+            .map(|col| format!("{}=EXCLUDED.{}", col, col))
+            .join(",");
+        let columns = columns.iter().join(",");
+        let mut values = Vec::with_capacity(value_sets.len());
+        for (idx, value_set) in value_sets.iter().enumerate() {
+            values.push(format!(
+                "({})",
+                ((1 + idx * value_set.len())..=(idx * value_set.len() + value_set.len()))
+                    .map(|i| format!("${i}"))
+                    .join(",")
+            ));
+        }
+        let values_clause = values.into_iter().join(",");
+
+        format!("INSERT INTO {table} ({columns}) VALUES {values_clause} ON CONFLICT({uniq_idx}) DO UPDATE SET {set_clause}")
     }
 }
 
@@ -28,7 +55,35 @@ impl Upsert<Sqlite> for Db {
     fn upsert_query(table: &str, values: &[Value], uniq_idx: &str) -> String {
         let columns = values.iter().map(|v| v.column.as_str()).join(",");
         let values_clause = (1..=values.len()).map(|_| "?").join(",");
-        let set_clause = values.iter().map(|v| format!("{}=?", v.column)).join(",");
+        let set_clause = values
+            .iter()
+            .map(|v| format!("{}=excluded.{}", v.column, v.column))
+            .join(",");
         format!("INSERT INTO {table} ({columns}) VALUES ({values_clause}) ON CONFLICT({uniq_idx}) DO UPDATE SET {set_clause}")
+    }
+
+    fn upsert_batch_query(
+        table: &str,
+        columns: &[String],
+        value_sets: &[Vec<Value>],
+        uniq_idx: &str,
+    ) -> String {
+        let set_clause = columns
+            .iter()
+            .map(|col| format!("{}=excluded.{}", col, col))
+            .join(",");
+        let columns = columns.iter().join(",");
+        let mut values = Vec::with_capacity(value_sets.len());
+        for (idx, value_set) in value_sets.iter().enumerate() {
+            values.push(format!(
+                "({})",
+                ((1 + idx * value_set.len())..=(idx * value_set.len() + value_set.len()))
+                    .map(|_| "?")
+                    .join(",")
+            ));
+        }
+        let values_clause = values.into_iter().join(",");
+
+        format!("INSERT INTO {table} ({columns}) VALUES {values_clause} ON CONFLICT({uniq_idx}) DO UPDATE SET {set_clause}")
     }
 }


### PR DESCRIPTION
In the config 'batch-size' and 'batch-interval' are added. The first controls how big batches are, and the latter will define how long a batch will be collected. Whichever happens first, the batch is full, or the time ran out. The connector sends a Query to insert/upsert all entries